### PR TITLE
Always fully collapse the sticky comment

### DIFF
--- a/app/src/main/java/me/edgan/redditslide/Adapters/CommentAdapter.java
+++ b/app/src/main/java/me/edgan/redditslide/Adapters/CommentAdapter.java
@@ -585,6 +585,14 @@ public class CommentAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
                 }
             }
 
+            if (SettingValues.collapseStickyComment) {
+                if (comment.getDataNode().has("stickied")
+                        && comment.getDataNode().get("stickied").asBoolean()) {
+                    holder.firstTextView.setVisibility(View.GONE);
+                    holder.commentOverflow.setVisibility(View.GONE);
+                }
+            }
+
         } else if (firstHolder instanceof SubmissionViewHolder && submission != null) {
             submissionViewHolder = (SubmissionViewHolder) firstHolder;
             new PopulateSubmissionViewHolder()

--- a/app/src/main/java/me/edgan/redditslide/SettingValues.java
+++ b/app/src/main/java/me/edgan/redditslide/SettingValues.java
@@ -67,6 +67,7 @@ public class SettingValues {
     public static final String PREF_COLLAPSE_COMMENTS = "collapseCOmments";
     public static final String PREF_COLLAPSE_COMMENTS_DEFAULT = "collapseCommentsDefault";
     public static final String PREF_COLLAPSE_DELETED_COMMENTS = "collapseDeletedComments";
+    public static final String PREF_COLLAPSE_STICKY_COMMENT = "collapseStickyComment";
     public static final String PREF_RIGHT_HANDED_COMMENT_MENU = "rightHandedCommentMenu";
     public static final String PREF_DUAL_PORTRAIT = "dualPortrait";
     public static final String PREF_SINGLE_COLUMN_MULTI = "singleColumnMultiWindow";
@@ -208,6 +209,7 @@ public class SettingValues {
     public static boolean collapseComments;
     public static boolean collapseCommentsDefault;
     public static boolean collapseDeletedComments;
+    public static boolean collapseStickyComment;
     public static boolean rightHandedCommentMenu;
     public static boolean abbreviateScores;
     public static boolean hidePostAwards;
@@ -385,6 +387,7 @@ public class SettingValues {
         collapseComments = prefs.getBoolean(PREF_COLLAPSE_COMMENTS, false);
         collapseCommentsDefault = prefs.getBoolean(PREF_COLLAPSE_COMMENTS_DEFAULT, false);
         collapseDeletedComments = prefs.getBoolean(PREF_COLLAPSE_DELETED_COMMENTS, false);
+        collapseStickyComment = prefs.getBoolean(PREF_COLLAPSE_STICKY_COMMENT, false);
         rightHandedCommentMenu = prefs.getBoolean(PREF_RIGHT_HANDED_COMMENT_MENU, false);
         commentAutoHide = prefs.getBoolean(PREF_AUTOHIDE_COMMENTS, false);
         showCollapseExpand = prefs.getBoolean(PREF_SHOW_COLLAPSE_EXPAND, false);

--- a/app/src/main/java/me/edgan/redditslide/ui/settings/SettingsCommentsFragment.java
+++ b/app/src/main/java/me/edgan/redditslide/ui/settings/SettingsCommentsFragment.java
@@ -59,6 +59,8 @@ public class SettingsCommentsFragment {
                 context.findViewById(R.id.settings_comments_collapseChildComments);
         final SwitchCompat commentsCollapseDeletedCommentsSwitch =
                 context.findViewById(R.id.settings_comments_collapseDeletedComments);
+        final SwitchCompat commentsCollapseStickyCommentSwitch =
+                context.findViewById(R.id.settings_comments_collapseStickyComment);
 
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         // * Display */
@@ -217,6 +219,14 @@ public class SettingsCommentsFragment {
                     SettingValues.collapseDeletedComments = isChecked;
                     editSharedBooleanPreference(
                             SettingValues.PREF_COLLAPSE_DELETED_COMMENTS, isChecked);
+                });
+        // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        commentsCollapseStickyCommentSwitch.setChecked(SettingValues.collapseStickyComment);
+        commentsCollapseStickyCommentSwitch.setOnCheckedChangeListener(
+                (buttonView, isChecked) -> {
+                    SettingValues.collapseStickyComment = isChecked;
+                    editSharedBooleanPreference(
+                            SettingValues.PREF_COLLAPSE_STICKY_COMMENT, isChecked);
                 });
     }
 

--- a/app/src/main/res/layout/activity_settings_comments_child.xml
+++ b/app/src/main/res/layout/activity_settings_comments_child.xml
@@ -817,4 +817,46 @@
             android:textColorHint="?attr/fontColor" />
     </RelativeLayout>
 
+    <View
+        android:layout_width="match_parent"
+        android:background="?attr/tintColor"
+        android:alpha=".25"
+        android:layout_height="0.25dp"/>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:background="?android:selectableItemBackground"
+        android:paddingStart="16dp">
+
+        <LinearLayout
+            android:layout_marginEnd="64dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_comments_collapse_sticky"
+                android:textColor="?attr/fontColor"
+                android:textSize="14sp" />
+        </LinearLayout>
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/settings_comments_collapseStickyComment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingEnd="16dp"
+            android:backgroundTint="?attr/tintColor"
+            android:button="@null"
+            android:buttonTint="?attr/tintColor"
+            android:hapticFeedbackEnabled="true"
+            android:textColor="?attr/fontColor"
+            android:textColorHint="?attr/fontColor" />
+    </RelativeLayout>
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -703,6 +703,7 @@
     <string name="settings_data_enable">Enable Data Saving settings</string>
     <string name="settings_data_video_quality">Prefer low-quality videos when Data Saving enabled</string>
     <string name="settings_comments_collapse_deleted">Collapse deleted comments by default</string>
+    <string name="settings_comments_collapse_sticky">Always fully collapse the sticky comment</string>
     <string name="settings_backup_occurs">Backup will occur at %1$s</string>
     <string name="settings_backup_none">No subreddits will back up</string>
     <string name="settings_backup_will_backup">\u0020will back up</string>


### PR DESCRIPTION
Hi, this PR adds the option to always fully collapse the stickied comment of a post.
I've simply followed the implementation of "Collapse deleted comment by default" for this, so it works the same way.

Closes #127 