### PR TITLE
fix: Inconsistent tap behavior on comments with media

### DIFF
--- a/app/src/main/java/me/edgan/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/edgan/redditslide/SpoilerRobotoTextView.java
@@ -79,7 +79,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 

--- a/app/src/main/java/me/edgan/redditslide/SpoilerRobotoTextView.java
+++ b/app/src/main/java/me/edgan/redditslide/SpoilerRobotoTextView.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 


### PR DESCRIPTION
Fixes the issue ( #70 ) where tapping empty space next to a linked image would incorrectly open the media. This provides consistent and intuitive tap behaviors across various comment structures involving text and media.